### PR TITLE
Converted DateString representation to UTCTime.

### DIFF
--- a/twitter-types/tests/Instances.hs
+++ b/twitter-types/tests/Instances.hs
@@ -4,13 +4,27 @@
 
 module Instances where
 
+import Data.String
 import Control.Applicative
 import Data.DeriveTH
 import qualified Data.Text as T
+import Data.Time
 import Test.QuickCheck
 import Web.Twitter.Types
 import Data.Aeson
 import Data.HashMap.Strict as HashMap
+import System.Locale
+
+instance IsString UTCTime where
+    fromString = readTime defaultTimeLocale twitterTimeFormat
+
+instance Arbitrary UTCTime where
+    arbitrary =
+        do randomDay <- choose (1, 29) :: Gen Int
+           randomMonth <- choose (1, 12) :: Gen Int
+           randomYear <- choose (2001, 2002) :: Gen Integer
+           randomTime <- choose (0, 86401) :: Gen Int
+           return $ UTCTime (fromGregorian randomYear randomMonth randomDay) (fromIntegral randomTime)
 
 instance Arbitrary T.Text where
     arbitrary = T.pack <$> arbitrary

--- a/twitter-types/tests/TypesTest.hs
+++ b/twitter-types/tests/TypesTest.hs
@@ -11,7 +11,6 @@ import Test.Framework.Providers.HUnit
 import Test.Framework.Providers.QuickCheck2
 import Test.HUnit
 
-import Debug.Trace
 import Data.Aeson hiding (Error)
 import Data.Aeson.Types (parseEither)
 import qualified Data.Aeson.Types as Aeson
@@ -267,7 +266,7 @@ case_parseList = withJSON fixture_list_thimura_haskell $ \obj -> do
 
 fromToJSON :: (Eq a, FromJSON a, ToJSON a) => a -> Bool
 fromToJSON obj = case fromJSON . toJSON $ obj of
-    Aeson.Error e -> trace e False
+    Aeson.Error _ -> False
     Aeson.Success a -> a == obj
 
 -- prop_fromToStreamingAPI :: StreamingAPI -> Bool

--- a/twitter-types/tests/TypesTest.hs
+++ b/twitter-types/tests/TypesTest.hs
@@ -11,6 +11,7 @@ import Test.Framework.Providers.HUnit
 import Test.Framework.Providers.QuickCheck2
 import Test.HUnit
 
+import Debug.Trace
 import Data.Aeson hiding (Error)
 import Data.Aeson.Types (parseEither)
 import qualified Data.Aeson.Types as Aeson
@@ -266,7 +267,7 @@ case_parseList = withJSON fixture_list_thimura_haskell $ \obj -> do
 
 fromToJSON :: (Eq a, FromJSON a, ToJSON a) => a -> Bool
 fromToJSON obj = case fromJSON . toJSON $ obj of
-    Aeson.Error _ -> False
+    Aeson.Error e -> trace e False
     Aeson.Success a -> a == obj
 
 -- prop_fromToStreamingAPI :: StreamingAPI -> Bool

--- a/twitter-types/twitter-types.cabal
+++ b/twitter-types/twitter-types.cabal
@@ -23,6 +23,8 @@ library
       base >= 4 && < 5
     , aeson >= 0.3.2.2
     , text
+    , time <1.5
+    , old-locale
     , unordered-containers
 
   if impl(ghc < 7.6)
@@ -49,10 +51,12 @@ test-suite tests
     , attoparsec
     , bytestring
     , text
+    , time
     , unordered-containers
     , filepath
     , directory
     , twitter-types
+    , old-locale
   other-modules:
     Fixtures
     Instances


### PR DESCRIPTION
In order to give twitter objects a more idiomatic Haskell representation, I've replace the DateString type with UTCTime and created a TwitterTime intermediate representation that allows Aeson to parse twitter's format.