### PR TITLE
Types: add Status field

### DIFF
--- a/twitter-types-lens/Web/Twitter/Types/Lens.hs
+++ b/twitter-types-lens/Web/Twitter/Types/Lens.hs
@@ -142,6 +142,7 @@ module Web.Twitter.Types.Lens
        , userProtected
        , userScreenName
        , userShowAllInlineMedia
+       , userStatus
        , userStatusesCount
        , userTimeZone
        , userURL

--- a/twitter-types/tests/Instances.hs
+++ b/twitter-types/tests/Instances.hs
@@ -66,6 +66,34 @@ instance Arbitrary Status where
                <*> arbitrary
                <*> arbitrary
 
+instance Arbitrary LastStatus where
+    arbitrary = do
+        LastStatus <$> arbitrary
+                   <*> arbitrary
+                   <*> arbitrary
+                   <*> arbitrary
+                   <*> arbitrary
+                   <*> arbitrary
+                   <*> arbitrary
+                   <*> arbitrary
+                   <*> arbitrary
+                   <*> arbitrary
+                   <*> arbitrary
+                   <*> arbitrary
+                   <*> arbitrary
+                   <*> arbitrary
+                   <*> arbitrary
+                   <*> arbitrary
+                   <*> pure Nothing
+                   <*> arbitrary
+                   <*> arbitrary
+                   <*> arbitrary
+                   <*> arbitrary
+                   <*> arbitrary
+                   <*> arbitrary
+                   <*> arbitrary
+                   <*> arbitrary
+
 derive makeArbitrary ''SearchStatus
 derive makeArbitrary ''SearchMetadata
 derive makeArbitrary ''RetweetedStatus

--- a/twitter-types/tests/TypesTest.hs
+++ b/twitter-types/tests/TypesTest.hs
@@ -259,12 +259,19 @@ case_parseUser = withJSON fixture_user_thimura $ \obj -> do
     lastStatusCreatedAt lastSt @?= "Fri Aug 01 12:59:36 +0000 2014"
     lastStatusLang lastSt @?= Just "ja"
     lastStatusRetweeted lastSt @?= Just False
+    lastStatusRetweetCount lastSt @?= 0
     lastStatusFavoriteCount lastSt @?= 0
     lastStatusInReplyToStatusId lastSt @?= Nothing
     lastStatusInReplyToScreenName lastSt @?= Nothing
     lastStatusInReplyToUserId lastSt @?= Nothing
     lastStatusSource lastSt @?= "\x003c\&a href=\"http://twitter.com\" rel=\"nofollow\"\x003eTwitter Web Client\003c/a\x003e"
     lastStatusCoordinates lastSt @?= Nothing
+    lastStatusContributors lastSt @?= Nothing
+    lastStatusPlace lastSt @?= Nothing
+    lastStatusText lastSt @?= "くそあつい"
+    lastStatusId lastSt @?= 495192122836783104
+    lastStatusTruncated lastSt @?= False
+    lastStatusEntities lastSt @?= Just (Entities [] [] [] [])
 
 case_parseList :: Assertion
 case_parseList = withJSON fixture_list_thimura_haskell $ \obj -> do

--- a/twitter-types/tests/TypesTest.hs
+++ b/twitter-types/tests/TypesTest.hs
@@ -252,6 +252,7 @@ case_parseUser = withJSON fixture_user_thimura $ \obj -> do
     userStatusesCount obj @?= 24709
     userLang obj @?= "en"
     userCreatedAt obj @?= "Thu Aug 27 02:48:06 +0000 2009"
+    lastStatusCreatedAt (fromJust $ userStatus obj) @?= "Fri Aug 01 12:59:36 +0000 2014"
     userFavoritesCount obj @?= 17313
 
 case_parseList :: Assertion

--- a/twitter-types/tests/TypesTest.hs
+++ b/twitter-types/tests/TypesTest.hs
@@ -252,8 +252,19 @@ case_parseUser = withJSON fixture_user_thimura $ \obj -> do
     userStatusesCount obj @?= 24709
     userLang obj @?= "en"
     userCreatedAt obj @?= "Thu Aug 27 02:48:06 +0000 2009"
-    lastStatusCreatedAt (fromJust $ userStatus obj) @?= "Fri Aug 01 12:59:36 +0000 2014"
     userFavoritesCount obj @?= 17313
+    let lastStatus = userStatus obj
+    assert $ isJust lastStatus
+    let lastSt = fromJust lastStatus
+    lastStatusCreatedAt lastSt @?= "Fri Aug 01 12:59:36 +0000 2014"
+    lastStatusLang lastSt @?= Just "ja"
+    lastStatusRetweeted lastSt @?= Just False
+    lastStatusFavoriteCount lastSt @?= 0
+    lastStatusInReplyToStatusId lastSt @?= Nothing
+    lastStatusInReplyToScreenName lastSt @?= Nothing
+    lastStatusInReplyToUserId lastSt @?= Nothing
+    lastStatusSource lastSt @?= "\x003c\&a href=\"http://twitter.com\" rel=\"nofollow\"\x003eTwitter Web Client\003c/a\x003e"
+    lastStatusCoordinates lastSt @?= Nothing
 
 case_parseList :: Assertion
 case_parseList = withJSON fixture_list_thimura_haskell $ \obj -> do

--- a/twitter-types/tests/TypesTest.hs
+++ b/twitter-types/tests/TypesTest.hs
@@ -279,6 +279,9 @@ prop_fromToStatus = fromToJSON
 prop_fromToSearchStatus :: SearchStatus -> Bool
 prop_fromToSearchStatus = fromToJSON
 
+prop_fromToLastStatus :: LastStatus -> Bool
+prop_fromToLastStatus = fromToJSON
+
 prop_fromToSearchMetadata :: SearchMetadata -> Bool
 prop_fromToSearchMetadata = fromToJSON
 


### PR DESCRIPTION
This is one attempt at trying to address #20. It probably isn't the best approach, but it was simple to implement.

According to the Twitter API docs at e.g. https://dev.twitter.com/rest/reference/get/users/lookup, a user can
have a "status" field corresponding to their last posted status (assuming you can have permission to read it).

This PR introduces a new type called LastStatus which is very similar to Status but missing a few fields:
- `lastStatusUser`, which doesn't seem to be present, perhaps because it's already "inside" a user object
- `lastStatusRetweetedStatus`, which seems to cause the tests to go into an infinite loop (and I haven't seen attested)

I'm not exactly sure why `lastStatusRetweetedStatus` causes the tests to go into an infinite loop, but my hypothesis is that the values generated by QuickCheck are being generated in a way that makes them infinite. Specifically, I assume that each Maybe value gets generated randomly, perhaps with a 50% chance of coming up Just. A RetweetedStatus, has both a Status and a User, and the Status has a Maybe RetweetedStatus and a User, and a User has a Maybe LastStatus. So given a single RetweetedStatus, there are three Maybe values that need to be filled in; if each is filled in with 50% probability, then on average one-and-a-half values will be produced that need to be filled in. Removing the RetweetedStatus from the LastStatus drops the number of Maybes to one.

Other fields in LastStatus might or might not be attested; anything that was Maybe, I copied in just in case it should show up somewhere.
