### PR TITLE
Fix type of statusCurrentUserRetweet (costmetic)

### DIFF
--- a/twitter-types/Web/Twitter/Types.hs
+++ b/twitter-types/Web/Twitter/Types.hs
@@ -120,7 +120,7 @@ data Status = Status
     { statusContributors :: Maybe [Contributor]
     , statusCoordinates :: Maybe Coordinates
     , statusCreatedAt :: UTCTime
-    , statusCurrentUserRetweet :: Maybe UserId
+    , statusCurrentUserRetweet :: Maybe StatusId
     , statusEntities :: Maybe Entities
     , statusExtendedEntities :: Maybe Entities
     , statusFavoriteCount :: Integer


### PR DESCRIPTION
According to https://dev.twitter.com/overview/api/tweets this field `current_user_retweet ` should be a StatusId instead of a UserId. Since both are aliases for Integer this shouldn't have an impact on users.