### PR TITLE
Fix build error in tests caused by time/old-locale discrepancy

### DIFF
--- a/twitter-types/tests/Instances.hs
+++ b/twitter-types/tests/Instances.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Instances where
@@ -8,12 +9,17 @@ import Data.String
 import Control.Applicative
 import Data.DeriveTH
 import qualified Data.Text as T
-import Data.Time (UTCTime (..), readTime, fromGregorian)
 import Test.QuickCheck
 import Web.Twitter.Types
 import Data.Aeson
 import Data.HashMap.Strict as HashMap
+
+#if MIN_VERSION_time(1,5,0)
+import Data.Time (UTCTime (..), readTime, fromGregorian, defaultTimeLocale)
+#else
+import Data.Time (UTCTime (..), readTime, fromGregorian)
 import System.Locale
+#endif
 
 instance IsString UTCTime where
     fromString = readTime defaultTimeLocale twitterTimeFormat


### PR DESCRIPTION
Using GHC 10.7.2, when the time15 flag was set, `defaultTimeLocale` was imported from old-locale rather than time, causing this type error:

    Preprocessing test suite 'tests' for twitter-types-0.7.0...
    [2 of 3] Compiling Instances        ( tests/Instances.hs, dist/dist-sandbox-cee30b45/build/tests/tests-tmp/Instances.o )

    tests/Instances.hs:19:27:
        Couldn't match expected type ‘time-1.5.0.1:Data.Time.Format.Locale.TimeLocale’
                    with actual type ‘TimeLocale’
        NB: ‘time-1.5.0.1:Data.Time.Format.Locale.TimeLocale’
              is defined in ‘Data.Time.Format.Locale’ in package ‘time-1.5.0.1’
            ‘TimeLocale’
              is defined in ‘System.Locale’ in package ‘old-locale-1.0.0.7’
        In the first argument of ‘readTime’, namely ‘defaultTimeLocale’
        In the expression: readTime defaultTimeLocale twitterTimeFormat