### PR TITLE
Support quoted tweets

### DIFF
--- a/twitter-types/Web/Twitter/Types.hs
+++ b/twitter-types/Web/Twitter/Types.hs
@@ -134,6 +134,8 @@ data Status = Status
     , statusPlace :: Maybe Place
     , statusPossiblySensitive :: Maybe Bool
     , statusScopes :: Maybe Object
+    , statusQuotedStatusId :: Maybe StatusId
+    , statusQuotedStatus :: Maybe Status
     , statusRetweetCount :: Integer
     , statusRetweeted :: Maybe Bool
     , statusRetweetedStatus :: Maybe Status
@@ -165,6 +167,8 @@ instance FromJSON Status where
                <*> o .:? "place"
                <*> o .:? "possibly_sensitive"
                <*> o .:? "scopes"
+               <*> o .:? "quoted_status_id"
+               <*> o .:? "quoted_status"
                <*> o .:? "retweet_count" .!= 0
                <*> o .:? "retweeted"
                <*> o .:? "retweeted_status"
@@ -197,6 +201,8 @@ instance ToJSON Status where
                                , "place"                    .= statusPlace
                                , "possibly_sensitive"       .= statusPossiblySensitive
                                , "scopes"                   .= statusScopes
+                               , "quoted_status_id"         .= statusQuotedStatusId
+                               , "quoted_status"            .= statusQuotedStatus
                                , "retweet_count"            .= statusRetweetCount
                                , "retweeted"                .= statusRetweeted
                                , "retweeted_status"         .= statusRetweetedStatus

--- a/twitter-types/tests/Instances.hs
+++ b/twitter-types/tests/Instances.hs
@@ -38,6 +38,8 @@ instance Arbitrary Value where
 
 instance Arbitrary Status where
     arbitrary = do
+        qt <- frequency [(5, Just <$> arbitrary), (95, pure Nothing)] :: Gen (Maybe Status)
+        rt <- frequency [(5, Just <$> arbitrary), (95, pure Nothing)] :: Gen (Maybe Status)
         Status <$> arbitrary
                <*> arbitrary
                <*> arbitrary
@@ -55,9 +57,11 @@ instance Arbitrary Status where
                <*> arbitrary
                <*> arbitrary
                <*> pure Nothing
+               <*> pure (statusId <$> qt)
+               <*> pure qt
                <*> arbitrary
                <*> arbitrary
-               <*> arbitrary
+               <*> pure rt
                <*> arbitrary
                <*> arbitrary
                <*> arbitrary

--- a/twitter-types/tests/TypesTest.hs
+++ b/twitter-types/tests/TypesTest.hs
@@ -44,6 +44,8 @@ case_parseStatus = withJSON fixture_status01 $ \obj -> do
     statusInReplyToStatusId obj @?= Nothing
     statusInReplyToUserId obj @?= Just 783214
     statusFavorited obj @?= Just False
+    statusQuotedStatus obj @?= Nothing
+    statusQuotedStatusId obj @?= Nothing
     statusRetweetCount obj @?= 0
     (userScreenName . statusUser) obj @?= "imeoin"
     statusRetweetedStatus obj @?= Nothing
@@ -52,6 +54,42 @@ case_parseStatus = withJSON fixture_status01 $ \obj -> do
     statusLang obj @?= Nothing
     statusPossiblySensitive obj @?= Just False
     statusCoordinates obj @?= Nothing
+
+case_parseStatusQuoted :: Assertion
+case_parseStatusQuoted = withJSON fixture_status_quoted $ \obj -> do
+    statusId obj @?= 641660763770372100
+    statusText obj @?= "Wow! Congrats! https://t.co/EPMMldEcci"
+    statusQuotedStatusId obj @?= Just 641653574284537900
+
+    let qs = fromJust $ statusQuotedStatus obj
+    statusCreatedAt qs @?= "Wed Sep 09 16:45:08 +0000 2015"
+    statusId qs @?= 641653574284537900
+    statusText qs @?= "Very happy to say that I'm joining @mesosphere as a Distributed Systems Engineer!"
+    statusSource qs @?= "<a href=\"http://twitter.com\" rel=\"nofollow\">Twitter Web Client</a>"
+
+    let ent = fromJust $ statusEntities qs
+    enURLs ent @?= []
+    enMedia ent @?= []
+    enHashTags ent @?= []
+    map (userEntityUserId . entityBody) (enUserMentions ent) @?= [1872399366]
+    map (userEntityUserScreenName . entityBody) (enUserMentions ent) @?= ["mesosphere"]
+
+    statusExtendedEntities qs @?= Nothing
+    statusInReplyToStatusId qs @?= Nothing
+    statusInReplyToUserId qs @?= Nothing
+    statusFavorited qs @?= Just False
+    statusQuotedStatus qs @?= Nothing
+    statusQuotedStatusId qs @?= Nothing
+    statusRetweetCount qs @?= 7
+    (userScreenName . statusUser) qs @?= "neil_conway"
+    statusRetweeted qs @?= Just False
+    statusRetweetedStatus qs @?= Nothing
+    statusPlace qs @?= Nothing
+    statusFavoriteCount qs @?= 63
+    statusLang qs @?= Just "en"
+    statusPossiblySensitive qs @?= Nothing
+    statusCoordinates qs @?= Nothing
+
 
 case_parseStatusWithPhoto :: Assertion
 case_parseStatusWithPhoto = withJSON fixture_status_thimura_with_photo $ \obj -> do

--- a/twitter-types/tests/fixtures/status_quoted.json
+++ b/twitter-types/tests/fixtures/status_quoted.json
@@ -1,0 +1,202 @@
+{
+  "created_at": "Wed Sep 09 17:13:42 +0000 2015",
+  "id": 641660763770372100,
+  "id_str": "641660763770372097",
+  "text": "Wow! Congrats! https://t.co/EPMMldEcci",
+  "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+  "truncated": false,
+  "in_reply_to_status_id": null,
+  "in_reply_to_status_id_str": null,
+  "in_reply_to_user_id": null,
+  "in_reply_to_user_id_str": null,
+  "in_reply_to_screen_name": null,
+  "user":  {
+    "id": 15232432,
+    "id_str": "15232432",
+    "name": "Dean Wampler",
+    "screen_name": "deanwampler",
+    "location": "Chicago",
+    "description": "Minor irritant, major pedant, Big Data, IoT, and Scala poser. Lurks at Typesafe. O'Reilly author. Opinions are my own..",
+    "url": "http://t.co/bzGTwCnmvO",
+    "entities":  {
+      "url":  {
+        "urls":  [
+           {
+            "url": "http://t.co/bzGTwCnmvO",
+            "expanded_url": "http://typesafe.com",
+            "display_url": "typesafe.com",
+            "indices":  [
+              0,
+              22
+            ]
+          }
+        ]
+      },
+      "description":  {
+        "urls":  []
+      }
+    },
+    "protected": false,
+    "followers_count": 7221,
+    "friends_count": 811,
+    "listed_count": 645,
+    "created_at": "Wed Jun 25 15:24:31 +0000 2008",
+    "favourites_count": 2841,
+    "utc_offset": -18000,
+    "time_zone": "Central Time (US & Canada)",
+    "geo_enabled": true,
+    "verified": false,
+    "statuses_count": 13483,
+    "lang": "en",
+    "contributors_enabled": false,
+    "is_translator": false,
+    "is_translation_enabled": false,
+    "profile_background_color": "9AE4E8",
+    "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/670120165/5514a5b016bf4d3d617ece5f117643d0.jpeg",
+    "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/670120165/5514a5b016bf4d3d617ece5f117643d0.jpeg",
+    "profile_background_tile": true,
+    "profile_image_url": "http://pbs.twimg.com/profile_images/639619926374748160/QhODNcWz_normal.jpg",
+    "profile_image_url_https": "https://pbs.twimg.com/profile_images/639619926374748160/QhODNcWz_normal.jpg",
+    "profile_banner_url": "https://pbs.twimg.com/profile_banners/15232432/1359038744",
+    "profile_link_color": "0000FF",
+    "profile_sidebar_border_color": "FFFFFF",
+    "profile_sidebar_fill_color": "DFF8A0",
+    "profile_text_color": "070708",
+    "profile_use_background_image": true,
+    "has_extended_profile": false,
+    "default_profile": false,
+    "default_profile_image": false,
+    "following": false,
+    "follow_request_sent": false,
+    "notifications": false
+  },
+  "geo": null,
+  "coordinates": null,
+  "place": null,
+  "contributors": null,
+  "quoted_status_id": 641653574284537900,
+  "quoted_status_id_str": "641653574284537856",
+  "quoted_status":  {
+    "created_at": "Wed Sep 09 16:45:08 +0000 2015",
+    "id": 641653574284537900,
+    "id_str": "641653574284537856",
+    "text": "Very happy to say that I'm joining @mesosphere as a Distributed Systems Engineer!",
+    "source": "<a href=\"http://twitter.com\" rel=\"nofollow\">Twitter Web Client</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user":  {
+      "id": 54129186,
+      "id_str": "54129186",
+      "name": "Neil Conway",
+      "screen_name": "neil_conway",
+      "location": "Oakland, CA",
+      "description": "Large-scale data management and distributed systems.",
+      "url": "http://t.co/grthxRo5Q1",
+      "entities":  {
+        "url":  {
+          "urls":  [
+             {
+              "url": "http://t.co/grthxRo5Q1",
+              "expanded_url": "http://neilconway.org",
+              "display_url": "neilconway.org",
+              "indices":  [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description":  {
+          "urls":  []
+        }
+      },
+      "protected": false,
+      "followers_count": 3380,
+      "friends_count": 680,
+      "listed_count": 202,
+      "created_at": "Mon Jul 06 05:43:15 +0000 2009",
+      "favourites_count": 611,
+      "utc_offset": -25200,
+      "time_zone": "Pacific Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 3559,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/204823473/Untitled-2.jpg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/204823473/Untitled-2.jpg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/299445365/3613789225_66f1cc848f_b_normal.jpg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/299445365/3613789225_66f1cc848f_b_normal.jpg",
+      "profile_link_color": "036E6E",
+      "profile_sidebar_border_color": "B05607",
+      "profile_sidebar_fill_color": "E8F0F0",
+      "profile_text_color": "998308",
+      "profile_use_background_image": true,
+      "has_extended_profile": false,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": true,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "is_quote_status": false,
+    "retweet_count": 7,
+    "favorite_count": 63,
+    "entities":  {
+      "hashtags":  [],
+      "symbols":  [],
+      "user_mentions":  [
+         {
+          "screen_name": "mesosphere",
+          "name": "Mesosphere",
+          "id": 1872399366,
+          "id_str": "1872399366",
+          "indices":  [
+            35,
+            46
+          ]
+        }
+      ],
+      "urls":  []
+    },
+    "favorited": false,
+    "retweeted": false,
+    "lang": "en"
+  },
+  "is_quote_status": true,
+  "retweet_count": 0,
+  "favorite_count": 1,
+  "entities":  {
+    "hashtags":  [],
+    "symbols":  [],
+    "user_mentions":  [],
+    "urls":  [
+       {
+        "url": "https://t.co/EPMMldEcci",
+        "expanded_url": "https://twitter.com/neil_conway/status/641653574284537856",
+        "display_url": "twitter.com/neil_conway/st…",
+        "indices":  [
+          15,
+          38
+        ]
+      }
+    ]
+  },
+  "favorited": false,
+  "retweeted": false,
+  "possibly_sensitive": false,
+  "possibly_sensitive_appealable": false,
+  "lang": "en"
+}


### PR DESCRIPTION
Twitter added support for referencing tweets via URL. The APIs expand the quoted tweet (similar to RTs) in a field named "quoted_status"

* https://dev.twitter.com/overview/api/tweets
* https://support.twitter.com/articles/20169873
* https://twitter.com/twitter/status/585225218093932544

I also reduced the probability of constructing deeply recursive `statusRetweetedStatus` in the `Arbitrary` instance, which should improve runtime and memory usage while running the tests.