### PR TITLE
Fix build error in Web.Twitter.Types

### DIFF
--- a/twitter-types/Web/Twitter/Types.hs
+++ b/twitter-types/Web/Twitter/Types.hs
@@ -360,7 +360,7 @@ data DirectMessage = DirectMessage
     } deriving (Show, Eq, Data, Typeable, Generic)
 
 parseIntegral :: Integral a => Text -> Parser a
-parseIntegral v = either (fail $ "couldn't parse stringized int: " ++ show v) (return . fst) $ decimal v
+parseIntegral v = either (\_ -> fail $ "couldn't parse stringized int: " ++ show v) (return . fst) $ decimal v
 
 epochMsToUTCTime :: Int64 -> UTCTime
 epochMsToUTCTime = posixSecondsToUTCTime . fromRational . (% 1000) . fromIntegral


### PR DESCRIPTION
Fixes the following build error:

```
Web/Twitter/Types.hs:363:27: error:
    • Could not deduce (MonadFail ((->) String))
        arising from a use of ‘fail’
      from the context: Integral a
        bound by the type signature for:
                   parseIntegral :: forall a. Integral a => Text -> Parser a
        at Web/Twitter/Types.hs:362:1-47
    • In the first argument of ‘either’, namely
        ‘(fail $ "couldn't parse stringized int: " ++ show v)’
      In the expression:
        either
          (fail $ "couldn't parse stringized int: " ++ show v) (return . fst)
      In the expression:
        either
          (fail $ "couldn't parse stringized int: " ++ show v) (return . fst)
          $ decimal v
    |
363 | parseIntegral v = either (fail $ "couldn't parse stringized int: " ++ show v) (return . fst) $ decimal v
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

A new release with this fix would be great :)